### PR TITLE
make tabs optimistically render on scroll but not click

### DIFF
--- a/src/basic/Tabs/ScrollableTabBar.js
+++ b/src/basic/Tabs/ScrollableTabBar.js
@@ -144,7 +144,7 @@ const ScrollableTabBar = createReactClass({
 
 		if (typeof name === "string") {
 			return (
-				<Button key={`${name}_${page}`} onPress={() => onPressHandler(page)} onLayout={onLayoutHandler}>
+				<Button key={`${name}_${page}`} onPress={() => onPressHandler(page, true)} onLayout={onLayoutHandler}>
 					<TabHeading scrollable style={isTabActive ? activeTabStyle : tabStyle} active={isTabActive}>
 						<Text style={isTabActive ? activeTextStyle : textStyle}>
 							{name}
@@ -154,7 +154,7 @@ const ScrollableTabBar = createReactClass({
 			);
 		} else {
 			return (
-				<Button key={_.random(1.2, 5.2)} onPress={() => onPressHandler(page)} onLayout={onLayoutHandler}>
+				<Button key={_.random(1.2, 5.2)} onPress={() => onPressHandler(page, true)} onLayout={onLayoutHandler}>
 					<TabHeading scrollable style={tabHeaderStyle} active={isTabActive}>
 						{headerContent}
 					</TabHeading>

--- a/src/basic/Tabs/ScrollableTabBar.js
+++ b/src/basic/Tabs/ScrollableTabBar.js
@@ -144,6 +144,7 @@ const ScrollableTabBar = createReactClass({
 
 		if (typeof name === "string") {
 			return (
+				// pass true because it is a click
 				<Button key={`${name}_${page}`} onPress={() => onPressHandler(page, true)} onLayout={onLayoutHandler}>
 					<TabHeading scrollable style={isTabActive ? activeTabStyle : tabStyle} active={isTabActive}>
 						<Text style={isTabActive ? activeTextStyle : textStyle}>
@@ -154,6 +155,7 @@ const ScrollableTabBar = createReactClass({
 			);
 		} else {
 			return (
+				// pass true because it is a click
 				<Button key={_.random(1.2, 5.2)} onPress={() => onPressHandler(page, true)} onLayout={onLayoutHandler}>
 					<TabHeading scrollable style={tabHeaderStyle} active={isTabActive}>
 						{headerContent}

--- a/src/basic/Tabs/index.js
+++ b/src/basic/Tabs/index.js
@@ -207,18 +207,25 @@ const ScrollableTabView = createReactClass({
       this._updateSelectedPage(page);
     }
   },
-
+  // function that optimistically renders the tab based on scrolling
   _optimisticRender(e) {
     const { currentPage, containerWidth, isClicked, gotNextPage } = this.state
+    // overall offset
     const offsetX = e.nativeEvent.contentOffset.x;
+    // offset in reference to screen (to get the scene it should scroll to)
     const currentPageOffset = offsetX / containerWidth
+    // change in page
     const deltaX = currentPageOffset - currentPage
+    // if there is a change (but not > 1 whole screen) and is not a click and the
+    // next page has not already been set to the current page
     if(Math.abs(deltaX) > 0 && Math.abs(deltaX) < 1 && !isClicked && !gotNextPage) {
+      // set the next page and scroll to it
       this.setState({ gotNextPage: true }, () => {
         const nextPage = deltaX > 0 ? currentPage + 1 : currentPage - 1
         this._updateSelectedPage(nextPage)
       })
     }
+    // if we are done scrolling, reset isClicked & gotNextPage
     if(!deltaX) {
       this.setState({ isClicked: false, gotNextPage: false })
     }

--- a/src/basic/Tabs/index.js
+++ b/src/basic/Tabs/index.js
@@ -58,6 +58,8 @@ const ScrollableTabView = createReactClass({
   getInitialState() {
     return {
       currentPage: this.props.initialPage,
+      gotNextPage: false,
+      isClicked: false,
       scrollValue: new Animated.Value(this.props.initialPage),
       containerWidth: Dimensions.get("window").width,
       sceneKeys: this.newSceneKeys({ currentPage: this.props.initialPage }),
@@ -89,21 +91,22 @@ const ScrollableTabView = createReactClass({
     }
   },
 
-  goToPage(pageNumber) {
+  goToPage(pageNumber, isClicked = false) {
     const offset = pageNumber * this.state.containerWidth;
-    if (this.scrollView) {
-      this.scrollView.scrollTo({
-        x: offset,
-        y: 0,
-        animated: !this.props.scrollWithoutAnimation,
+    this.setState({ isClicked: isClicked }, () => {
+      if (this.scrollView) {
+        this.scrollView.scrollTo({
+          x: offset,
+          y: 0,
+          animated: !this.props.scrollWithoutAnimation,
+        });
+      }
+      const currentPage = this.state.currentPage;
+      this.updateSceneKeys({
+        page: pageNumber,
+        callback: this._onChangeTab.bind(this, currentPage, pageNumber),
       });
-    }
-
-    const currentPage = this.state.currentPage;
-    this.updateSceneKeys({
-      page: pageNumber,
-      callback: this._onChangeTab.bind(this, currentPage, pageNumber),
-    });
+    })
   },
 
   renderTabBar(props) {
@@ -162,18 +165,7 @@ const ScrollableTabView = createReactClass({
         ref={scrollView => {
           this.scrollView = scrollView;
         }}
-        onScroll={e => {
-          const offsetX = e.nativeEvent.contentOffset.x;
-          const currentPage = this.state.currentPage
-          const currentPageOffset = offsetX / this.state.containerWidth
-          const deltaX = currentPageOffset - currentPage
-          if(Math.abs(deltaX) >= 0 && Math.abs(deltaX) < 1) {
-            const nextPage = deltaX > 0 ? currentPage + 1 : currentPage - 1
-            this._updateSelectedPage(nextPage)
-          }
-          this._updateScrollValue(offsetX / this.state.containerWidth)
-        }}
-        onMomentumScrollBegin={this._onMomentumScrollBeginAndEnd}
+        onScroll={this._optimisticRender}
         onMomentumScrollEnd={this._onMomentumScrollBeginAndEnd}
         scrollEventThrottle={16}
         scrollsToTop={false}
@@ -214,6 +206,23 @@ const ScrollableTabView = createReactClass({
     if (this.state.currentPage !== page) {
       this._updateSelectedPage(page);
     }
+  },
+
+  _optimisticRender(e) {
+    const { currentPage, containerWidth, isClicked, gotNextPage } = this.state
+    const offsetX = e.nativeEvent.contentOffset.x;
+    const currentPageOffset = offsetX / containerWidth
+    const deltaX = currentPageOffset - currentPage
+    if(Math.abs(deltaX) > 0 && Math.abs(deltaX) < 1 && !isClicked && !gotNextPage) {
+      this.setState({ gotNextPage: true }, () => {
+        const nextPage = deltaX > 0 ? currentPage + 1 : currentPage - 1
+        this._updateSelectedPage(nextPage)
+      })
+    }
+    if(!deltaX) {
+      this.setState({ isClicked: false, gotNextPage: false })
+    }
+    this._updateScrollValue(offsetX / this.state.containerWidth)
   },
 
   _updateSelectedPage(nextPage) {


### PR DESCRIPTION
- optimistically render tabs on scroll but not click
- overcome weird alternating rendering issue by capturing when a tab is clicked and when the value of the next page is initially set